### PR TITLE
Replace static News page with link to GitHub releases

### DIFF
--- a/tab_news.md
+++ b/tab_news.md
@@ -1,50 +1,27 @@
 ---
-
 title: News
 layout: null
 order: 4
 tab: true
 tags: dependency-track dtrack
-
 ---
 
 ## News
 
-* 2022/05/18 [v4.5.0](https://docs.dependencytrack.org/2022/05/18/v4.5.0/) Released
-* 2022/02/18 [v4.4.1](https://docs.dependencytrack.org/2022/02/18/v4.4.1/) Released
-* 2022/02/17 [v4.4.0](https://docs.dependencytrack.org/2022/02/17/v4.4.0/) Released
-* 2021/09/20 [v4.3.6](https://docs.dependencytrack.org/2021/09/20/v4.3.6/) Released
-* 2021/09/20 [v4.3.5](https://docs.dependencytrack.org/2021/09/20/v4.3.5/) Released
-* 2021/08/31 [v4.3.4](https://docs.dependencytrack.org/2021/08/31/v4.3.4/) Released
-* 2021/08/20 [v4.3.3](https://docs.dependencytrack.org/2021/08/20/v4.3.3/) Released
-* 2021/08/07 [v4.3.2](https://docs.dependencytrack.org/2021/08/07/v4.3.2/) Released
-* 2021/08/03 [v4.3.1](https://docs.dependencytrack.org/2021/08/03/v4.3.1/) Released
-* 2021/08/02 [v4.3.0](https://docs.dependencytrack.org/2021/08/02/v4.3.0/) Released
-* 2021/05/07 [v4.2.2](https://docs.dependencytrack.org/2021/05/07/v4.2.2/) Released
-* 2021/03/20 [v4.2.1](https://docs.dependencytrack.org/2021/03/20/v4.2.1/) Released
-* 2021/03/17 [v4.2.0](https://docs.dependencytrack.org/2021/03/17/v4.2.0/) Released
-* 2021/02/09 [v4.1.0](https://docs.dependencytrack.org/2021/02/09/v4.1.0/) Released
-* 2021/01/12 [v4.0.1](https://docs.dependencytrack.org/2021/01/12/v4.0.1/) Released
-* 2021/01/03 [v4.0.0](https://docs.dependencytrack.org/2021/01/03/v4.0.0/) Released
-* 2020/03/22 [v3.8.0](https://docs.dependencytrack.org/2020/03/22/v3.8.0/) Released
-* 2020/01/07 [v3.7.1](https://docs.dependencytrack.org/2020/01/07/v3.7.1/) Released
-* 2019/12/16 [v3.7.0](https://docs.dependencytrack.org/2019/12/16/v3.7.0/) Released
-* 2019/10/01 [v3.6.1](https://docs.dependencytrack.org/2019/10/01/v3.6.1/) Released
-* 2019/09/28 [v3.6.0](https://docs.dependencytrack.org/2019/09/28/v3.6.0/) Released
-* 2019/07/17 [v3.5.1](https://docs.dependencytrack.org/2019/07/17/v3.5.1/) Released
-* 2019/06/07 [v3.5.0](https://docs.dependencytrack.org/2019/06/07/v3.5.0/) Released
-* 2019/04/16 [v3.4.1](https://docs.dependencytrack.org/2019/04/16/v3.4.1/) Released
-* 2018/12/22 [v3.4.0](https://docs.dependencytrack.org/2018/12/22/v3.4.0/) Released
-* 2018/11/13 [v3.3.1](https://docs.dependencytrack.org/2018/11/13/v3.3.1/) Released 
-* 2018/10/25 [v3.3.0](https://docs.dependencytrack.org/2018/10/25/v3.3.0/) Released 
-* 2018/10/02 [v3.2.2](https://docs.dependencytrack.org/2018/10/02/v3.2.2/) Released 
-* 2018/09/21 [v3.2.1](https://docs.dependencytrack.org/2018/09/21/v3.2.1/) Released 
-* 2018/09/06 [v3.2.0](https://docs.dependencytrack.org/2018/09/06/v3.2.0/) Released 
-* 2018/06/19 [v3.1.0](https://docs.dependencytrack.org/2018/06/19/v3.1.0/) Released 
-* 2018/05/02 [v3.0.4](https://docs.dependencytrack.org/2018/05/02/v3.0.4/) Released 
-* 2018/04/13 [v3.0.3](https://docs.dependencytrack.org/2018/04/13/v3.0.3/) Released 
-* 2018/03/30 [v3.0.2](https://docs.dependencytrack.org/2018/03/30/v3.0.2/) Released 
-* 2018/03/29 [v3.0.1](https://docs.dependencytrack.org/2018/03/29/v3.0.1/) Released 
-* 2018/03/27 [v3.0.0](https://docs.dependencytrack.org/2018/03/27/v3.0.0/) Released 
-* 2017/10/08 [v3.0 Updates to community](https://groups.google.com/forum/#!topic/dependency-track/0PUJI5rNgzI)
-* 2017/06/16 [Presentation at OWASP Summit 2017](https://www.youtube.com/watch?v=88YAlzuDH04&t=50s)
+The latest releases of Dependency-Track are published on GitHub.
+
+👉 **View all releases:**  
+https://github.com/DependencyTrack/dependency-track/releases
+
+For detailed release notes and documentation, please visit:
+
+📖 **Release announcements & documentation:**  
+https://docs.dependencytrack.org/
+
+---
+
+To stay up to date:
+
+- Watch the project on GitHub for release notifications
+- Follow the OWASP Dependency-Track project page
+- Join the OWASP Slack (#dependency-track channel)


### PR DESCRIPTION
The News tab currently contains a manually maintained list of historical releases, which has become outdated.

This PR replaces the static release list with a link to the GitHub Releases page and the official documentation site.

Benefits:
- Avoids stale content
- Reduces manual maintenance effort
- Points users to the canonical and always up-to-date release source